### PR TITLE
Serve webp images when possible

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,14 @@ http.createServer( function( request, response ) {
 		return response.end()
 	}
 
-	return tachyon.s3( config, decodeURI( params.pathname.substr(1) ), params.query, function( err, data, info ) {
+	let args = params.query;
+
+	let accept = request.headers['accept'] ? request.headers['accept'] : "";
+	if (accept.includes('webp')) {
+		args.webp = true
+	}
+
+	return tachyon.s3( config, decodeURI( params.pathname.substr(1) ), args, function( err, data, info ) {
 		if ( err ) {
 			if ( debug ) {
 				console.error( Date(), err )


### PR DESCRIPTION
According to Google's documentation as well as my own testing, using webp images saves around 30% on file size. To implement this, I check the request headers to see if webp is accepted by the browser. If so, 'webp' is set to true on the arguments for tachyon.s3().